### PR TITLE
Add EthicalAds.io - our new ad network for developer sites

### DIFF
--- a/lists/opensource.txt
+++ b/lists/opensource.txt
@@ -1,3 +1,6 @@
+! EthicalAds.io is the ad network for tech sites from Read the Docs
+@@||ethicalads.io/*
+
 ! Filezilla Ads are blocked by generic rules on the EasyList
 @@ads.filezilla-project.org
 filezilla-project.org#@#.TopAd


### PR DESCRIPTION
Now that EthicalAds is on the easylist, we should allow list it.