### PR TITLE
update link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,5 +23,5 @@ Read the Docs Ads (`view list <https://ads-for-open-source.readthedocs.io/en/lat
     policy of `ethical advertising`_ which takes privacy seriously. This list
     is a strict subset of the Open Source Ads list.
 
-.. _read more: https://ads-for-open-source.readthedocs.io/en/latest/installation.html
+.. _read more: https://ads-for-open-source.readthedocs.io/en/latest/inclusion.html
 .. _ethical advertising: https://docs.readthedocs.io/en/latest/ethical-advertising.html

--- a/README.rst
+++ b/README.rst
@@ -23,5 +23,5 @@ Read the Docs Ads (`view list <https://ads-for-open-source.readthedocs.io/en/lat
     policy of `ethical advertising`_ which takes privacy seriously. This list
     is a strict subset of the Open Source Ads list.
 
-.. _read more: https://ads-for-open-source.readthedocs.io/inclusion.html
+.. _read more: https://ads-for-open-source.readthedocs.io/en/latest/installation.html
 .. _ethical advertising: https://docs.readthedocs.io/en/latest/ethical-advertising.html


### PR DESCRIPTION
I'm not sure what the desired solution is.  The README here and a number of other places referencing this list refer to [`https://ads-for-open-source.readthedocs.io/inclusion.html`](https://ads-for-open-source.readthedocs.io/inclusion.html).  This PR fixes the link locally, but would it make sense to also recreate `/inclusion.html` and have it redirect there?